### PR TITLE
Add structured logging and centralized API error handling

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -92,6 +92,7 @@ components:
           properties:
             code: { type: string }
             message: { type: string }
+            detail: { type: string, description: Present on SERVER_ERROR when API_DEBUG is enabled (local testing). }
             entity: { description: Present on 409 CONFLICT (current resource) }
     Plan:
       type: object

--- a/handler/api_v1.go
+++ b/handler/api_v1.go
@@ -132,7 +132,7 @@ func (h *Handler) APIListPlans(c echo.Context) error {
 		LimitCount:   limit + 1,
 	})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not list plans.")
+		return apijson.ServerError(c, "Could not list plans.", err)
 	}
 
 	next := ""
@@ -166,7 +166,7 @@ func (h *Handler) APICreatePlan(c echo.Context) error {
 	dq := database.New(h.DB)
 	p, err := dq.CreatePlan(ctx, database.CreatePlanParams{Name: body.Name, User: uid})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not create plan.")
+		return apijson.ServerError(c, "Could not create plan.", err)
 	}
 	return c.JSON(http.StatusCreated, planToDTO(p))
 }
@@ -187,7 +187,7 @@ func (h *Handler) APIGetPlan(c echo.Context) error {
 		if errors.Is(err, sql.ErrNoRows) {
 			return apijson.Error(c, http.StatusNotFound, "NOT_FOUND", "Plan not found.")
 		}
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not load plan.")
+		return apijson.ServerError(c, "Could not load plan.", err)
 	}
 	return c.JSON(http.StatusOK, planToDTO(p))
 }
@@ -226,7 +226,7 @@ func (h *Handler) APIPatchPlan(c echo.Context) error {
 			BaseUpdatedAt: base,
 		})
 		if err != nil {
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not update plan.")
+			return apijson.ServerError(c, "Could not update plan.", err)
 		}
 		if n == 0 {
 			cur, gerr := dq.GetPlan(ctx, database.GetPlanParams{ID: id, UserId: uid})
@@ -237,12 +237,12 @@ func (h *Handler) APIPatchPlan(c echo.Context) error {
 		}
 	} else {
 		if err := dq.UpdatePlan(ctx, database.UpdatePlanParams{Name: body.Name, ID: id, UserId: uid}); err != nil {
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not update plan.")
+			return apijson.ServerError(c, "Could not update plan.", err)
 		}
 	}
 	p, err := dq.GetPlan(ctx, database.GetPlanParams{ID: id, UserId: uid})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not load plan.")
+		return apijson.ServerError(c, "Could not load plan.", err)
 	}
 	return c.JSON(http.StatusOK, planToDTO(p))
 }
@@ -259,7 +259,7 @@ func (h *Handler) APIDeletePlan(c echo.Context) error {
 	ctx := c.Request().Context()
 	dq := database.New(h.DB)
 	if err := dq.DeletePlan(ctx, database.DeletePlanParams{ID: id, UserId: uid}); err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not delete plan.")
+		return apijson.ServerError(c, "Could not delete plan.", err)
 	}
 	return c.NoContent(http.StatusNoContent)
 }

--- a/handler/api_v1_resources_templates.go
+++ b/handler/api_v1_resources_templates.go
@@ -96,7 +96,7 @@ func (h *Handler) APIListResources(c echo.Context) error {
 		LimitCount:   limit + 1,
 	})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not list resources.")
+		return apijson.ServerError(c, "Could not list resources.", err)
 	}
 
 	next := ""
@@ -143,7 +143,7 @@ func (h *Handler) APICreateResource(c echo.Context) error {
 		Content:      content,
 	})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not create resource.")
+		return apijson.ServerError(c, "Could not create resource.", err)
 	}
 	return c.JSON(http.StatusCreated, resourceToDTO(r))
 }
@@ -164,7 +164,7 @@ func (h *Handler) APIGetResource(c echo.Context) error {
 		if errors.Is(err, sql.ErrNoRows) {
 			return apijson.Error(c, http.StatusNotFound, "NOT_FOUND", "Resource not found.")
 		}
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not load resource.")
+		return apijson.ServerError(c, "Could not load resource.", err)
 	}
 	return c.JSON(http.StatusOK, resourceToDTO(r))
 }
@@ -211,7 +211,7 @@ func (h *Handler) APIPatchResource(c echo.Context) error {
 			BaseUpdatedAt: base,
 		})
 		if err != nil {
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not update resource.")
+			return apijson.ServerError(c, "Could not update resource.", err)
 		}
 		if n == 0 {
 			cur, gerr := dq.GetResource(ctx, database.GetResourceParams{ID: id, UserId: uid})
@@ -228,12 +228,12 @@ func (h *Handler) APIPatchResource(c echo.Context) error {
 			ID:           id,
 			UserId:       uid,
 		}); err != nil {
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not update resource.")
+			return apijson.ServerError(c, "Could not update resource.", err)
 		}
 	}
 	r, err := dq.GetResource(ctx, database.GetResourceParams{ID: id, UserId: uid})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not load resource.")
+		return apijson.ServerError(c, "Could not load resource.", err)
 	}
 	return c.JSON(http.StatusOK, resourceToDTO(r))
 }
@@ -250,7 +250,7 @@ func (h *Handler) APIDeleteResource(c echo.Context) error {
 	ctx := c.Request().Context()
 	dq := database.New(h.DB)
 	if err := dq.DeleteResource(ctx, database.DeleteResourceParams{ID: id, UserId: uid}); err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not delete resource.")
+		return apijson.ServerError(c, "Could not delete resource.", err)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -312,7 +312,7 @@ func (h *Handler) APIListTemplates(c echo.Context) error {
 		LimitCount:   limit + 1,
 	})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not list templates.")
+		return apijson.ServerError(c, "Could not list templates.", err)
 	}
 	next := ""
 	if len(rows) > int(limit) {
@@ -354,7 +354,7 @@ func (h *Handler) APICreateTemplate(c echo.Context) error {
 		Description: body.Description,
 	})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not create template.")
+		return apijson.ServerError(c, "Could not create template.", err)
 	}
 	return c.JSON(http.StatusCreated, templateToDTO(t))
 }
@@ -375,7 +375,7 @@ func (h *Handler) APIGetTemplate(c echo.Context) error {
 		if errors.Is(err, sql.ErrNoRows) {
 			return apijson.Error(c, http.StatusNotFound, "NOT_FOUND", "Template not found.")
 		}
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not load template.")
+		return apijson.ServerError(c, "Could not load template.", err)
 	}
 	return c.JSON(http.StatusOK, templateToDTO(t))
 }
@@ -418,7 +418,7 @@ func (h *Handler) APIPatchTemplate(c echo.Context) error {
 			BaseUpdatedAt: base,
 		})
 		if err != nil {
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not update template.")
+			return apijson.ServerError(c, "Could not update template.", err)
 		}
 		if n == 0 {
 			cur, gerr := dq.GetTemplate(ctx, database.GetTemplateParams{ID: id, UserId: uid})
@@ -435,12 +435,12 @@ func (h *Handler) APIPatchTemplate(c echo.Context) error {
 			ID:          id,
 			UserId:      uid,
 		}); err != nil {
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not update template.")
+			return apijson.ServerError(c, "Could not update template.", err)
 		}
 	}
 	t, err := dq.GetTemplate(ctx, database.GetTemplateParams{ID: id, UserId: uid})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not load template.")
+		return apijson.ServerError(c, "Could not load template.", err)
 	}
 	return c.JSON(http.StatusOK, templateToDTO(t))
 }
@@ -457,7 +457,7 @@ func (h *Handler) APIDeleteTemplate(c echo.Context) error {
 	ctx := c.Request().Context()
 	dq := database.New(h.DB)
 	if err := dq.DeleteTemplate(ctx, database.DeleteTemplateParams{ID: id, UserId: uid}); err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not delete template.")
+		return apijson.ServerError(c, "Could not delete template.", err)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -515,7 +515,7 @@ func (h *Handler) APIListPlanAccess(c echo.Context) error {
 		LimitCount:   limit + 1,
 	})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not list plan access rows.")
+		return apijson.ServerError(c, "Could not list plan access rows.", err)
 	}
 	next := ""
 	if len(rows) > int(limit) {

--- a/handler/api_v1_tasks.go
+++ b/handler/api_v1_tasks.go
@@ -60,7 +60,7 @@ func (h *Handler) APIListTasks(c echo.Context) error {
 			UserId: uid,
 		})
 		if err != nil {
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not list tasks.")
+			return apijson.ServerError(c, "Could not list tasks.", err)
 		}
 		out := make([]taskDTO, 0, len(tasks))
 		for _, t := range tasks {
@@ -92,7 +92,7 @@ func (h *Handler) APIListTasks(c echo.Context) error {
 		LimitCount:   limit + 1,
 	})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not list tasks.")
+		return apijson.ServerError(c, "Could not list tasks.", err)
 	}
 	next := ""
 	if len(rows) > int(limit) {
@@ -130,7 +130,7 @@ func (h *Handler) APIListTasksWeek(c echo.Context) error {
 		Dates:  dates,
 	})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not list week tasks.")
+		return apijson.ServerError(c, "Could not list week tasks.", err)
 	}
 	out := make([]taskDTO, 0, len(tasks))
 	for _, t := range tasks {
@@ -172,7 +172,7 @@ func (h *Handler) APICreateTask(c echo.Context) error {
 			if errors.Is(err, sql.ErrNoRows) {
 				return apijson.Error(c, http.StatusBadRequest, "BAD_REQUEST", "Template not found or inaccessible.")
 			}
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not create task from template.")
+			return apijson.ServerError(c, "Could not create task from template.", err)
 		}
 		return c.JSON(http.StatusCreated, taskToDTO(t))
 	}
@@ -184,7 +184,7 @@ func (h *Handler) APICreateTask(c echo.Context) error {
 		Description: body.Description,
 	})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not create task.")
+		return apijson.ServerError(c, "Could not create task.", err)
 	}
 	return c.JSON(http.StatusCreated, taskToDTO(t))
 }
@@ -205,7 +205,7 @@ func (h *Handler) APIGetTask(c echo.Context) error {
 		if errors.Is(err, sql.ErrNoRows) {
 			return apijson.Error(c, http.StatusNotFound, "NOT_FOUND", "Task not found.")
 		}
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not load task.")
+		return apijson.ServerError(c, "Could not load task.", err)
 	}
 	return c.JSON(http.StatusOK, taskToDTO(t))
 }
@@ -253,7 +253,7 @@ func (h *Handler) APIPatchTask(c echo.Context) error {
 			BaseUpdatedAt: base,
 		})
 		if err != nil {
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not update task.")
+			return apijson.ServerError(c, "Could not update task.", err)
 		}
 		if n == 0 {
 			cur, gerr := dq.GetTask(ctx, database.GetTaskParams{ID: id, UserId: uid})
@@ -272,12 +272,12 @@ func (h *Handler) APIPatchTask(c echo.Context) error {
 			UserId:      uid,
 		})
 		if err != nil {
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not update task.")
+			return apijson.ServerError(c, "Could not update task.", err)
 		}
 	}
 	t, err := dq.GetTask(ctx, database.GetTaskParams{ID: id, UserId: uid})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not load task.")
+		return apijson.ServerError(c, "Could not load task.", err)
 	}
 	return c.JSON(http.StatusOK, taskToDTO(t))
 }
@@ -294,7 +294,7 @@ func (h *Handler) APIDeleteTask(c echo.Context) error {
 	ctx := c.Request().Context()
 	dq := database.New(h.DB)
 	if err := dq.DeleteTask(ctx, database.DeleteTaskParams{ID: id, UserId: uid}); err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not delete task.")
+		return apijson.ServerError(c, "Could not delete task.", err)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -334,7 +334,7 @@ func (h *Handler) APIPatchTaskComplete(c echo.Context) error {
 			if errors.Is(err, sql.ErrNoRows) {
 				return apijson.Error(c, http.StatusNotFound, "NOT_FOUND", "Task not found.")
 			}
-			return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not load task.")
+			return apijson.ServerError(c, "Could not load task.", err)
 		}
 		if cur.UpdatedAt != base {
 			return apijson.Conflict(c, taskToDTO(cur))
@@ -345,11 +345,11 @@ func (h *Handler) APIPatchTaskComplete(c echo.Context) error {
 		ID:         id,
 		UserId:     uid,
 	}); err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not update task.")
+		return apijson.ServerError(c, "Could not update task.", err)
 	}
 	t, err := dq.GetTask(ctx, database.GetTaskParams{ID: id, UserId: uid})
 	if err != nil {
-		return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Could not load task.")
+		return apijson.ServerError(c, "Could not load task.", err)
 	}
 	return c.JSON(http.StatusOK, taskToDTO(t))
 }

--- a/internal/apijson/apijson.go
+++ b/internal/apijson/apijson.go
@@ -1,19 +1,48 @@
 package apijson
 
 import (
+	"log/slog"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/labstack/echo/v4"
 )
 
+// IncludeDetail controls whether SERVER_ERROR responses include an error.detail field.
+// Enabled when API_DEBUG is 1, true, or yes (useful when testing endpoints locally).
+var IncludeDetail = apiDebugEnabled()
+
+func apiDebugEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("API_DEBUG")))
+	return v == "1" || v == "true" || v == "yes"
+}
+
 // Error writes a consistent JSON error envelope for /api/v1.
 func Error(c echo.Context, status int, code, message string) error {
+	if status >= http.StatusInternalServerError {
+		logRequestError(c, code, message, nil)
+	}
 	return c.JSON(status, map[string]any{
 		"error": map[string]string{
 			"code":    code,
 			"message": message,
 		},
 	})
+}
+
+// ServerError logs the underlying error and returns a SERVER_ERROR JSON envelope.
+// When API_DEBUG is set, the response includes error.detail with err.Error().
+func ServerError(c echo.Context, message string, err error) error {
+	logRequestError(c, "SERVER_ERROR", message, err)
+	errBody := map[string]string{
+		"code":    "SERVER_ERROR",
+		"message": message,
+	}
+	if IncludeDetail && err != nil {
+		errBody["detail"] = err.Error()
+	}
+	return c.JSON(http.StatusInternalServerError, map[string]any{"error": errBody})
 }
 
 // Conflict writes 409 with the server's current entity under error.entity for sync conflicts.
@@ -25,4 +54,23 @@ func Conflict(c echo.Context, entity any) error {
 			"entity":  entity,
 		},
 	})
+}
+
+func logRequestError(c echo.Context, code, message string, err error) {
+	attrs := []any{
+		"method", c.Request().Method,
+		"path", c.Request().URL.Path,
+		"code", code,
+		"message", message,
+	}
+	if rid := c.Response().Header().Get(echo.HeaderXRequestID); rid != "" {
+		attrs = append(attrs, "request_id", rid)
+	}
+	if uid, ok := c.Get("api_user_sub").(string); ok && uid != "" {
+		attrs = append(attrs, "user", uid)
+	}
+	if err != nil {
+		attrs = append(attrs, "err", err)
+	}
+	slog.Error("api error", attrs...)
 }

--- a/internal/apijson/apijson_test.go
+++ b/internal/apijson/apijson_test.go
@@ -1,0 +1,72 @@
+package apijson_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sknutsen/planner/internal/apijson"
+)
+
+func TestServerErrorWithoutDetail(t *testing.T) {
+	apijson.IncludeDetail = false
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/plans", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := apijson.ServerError(c, "Could not list plans.", errors.New("db timeout"))
+	if err != nil {
+		t.Fatalf("ServerError returned error: %v", err)
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+
+	var body map[string]map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["error"]["code"] != "SERVER_ERROR" {
+		t.Fatalf("code = %q", body["error"]["code"])
+	}
+	if body["error"]["message"] != "Could not list plans." {
+		t.Fatalf("message = %q", body["error"]["message"])
+	}
+	if _, ok := body["error"]["detail"]; ok {
+		t.Fatal("detail should be omitted when API_DEBUG is off")
+	}
+}
+
+func TestServerErrorWithDetail(t *testing.T) {
+	apijson.IncludeDetail = true
+	t.Cleanup(func() { apijson.IncludeDetail = apijsonDebugFromEnv() })
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/plans", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	root := errors.New("db timeout")
+	if err := apijson.ServerError(c, "Could not list plans.", root); err != nil {
+		t.Fatalf("ServerError returned error: %v", err)
+	}
+
+	var body map[string]map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["error"]["detail"] != "db timeout" {
+		t.Fatalf("detail = %q, want %q", body["error"]["detail"], "db timeout")
+	}
+}
+
+func apijsonDebugFromEnv() bool {
+	v := os.Getenv("API_DEBUG")
+	return v == "1" || v == "true" || v == "yes"
+}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,9 @@ package main
 import (
 	"encoding/gob"
 	"fmt"
+	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/joho/godotenv"
 	"github.com/labstack/echo/v4"
@@ -14,6 +16,8 @@ import (
 )
 
 func main() {
+	setupLogging()
+
 	err := godotenv.Load(".env")
 	if err != nil {
 		fmt.Printf("Could not load .env file. Err: %s\n", err)
@@ -75,4 +79,17 @@ func main() {
 	router.Setup(e, h)
 
 	e.Logger.Fatal(e.Start(fmt.Sprintf(":%s", h.Port)))
+}
+
+func setupLogging() {
+	level := slog.LevelInfo
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("LOG_LEVEL"))) {
+	case "debug":
+		level = slog.LevelDebug
+	case "warn", "warning":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
 }

--- a/middleware/api_idempotency.go
+++ b/middleware/api_idempotency.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -62,7 +63,7 @@ func IdempotencyBuffer(db database.DBTX) echo.MiddlewareFunc {
 				return werr
 			}
 			if !errors.Is(err, sql.ErrNoRows) {
-				return apijson.Error(c, http.StatusInternalServerError, "SERVER_ERROR", "Idempotency lookup failed.")
+				return apijson.ServerError(c, "Idempotency lookup failed.", err)
 			}
 
 			rw := &captureWriter{ResponseWriter: c.Response().Writer}
@@ -97,6 +98,13 @@ func IdempotencyBuffer(db database.DBTX) echo.MiddlewareFunc {
 					// Another request completed the same idempotent call; response already sent to client.
 					return nil
 				}
+			} else if insErr != nil {
+				slog.Error("idempotency cache write failed",
+					"path", c.Request().URL.Path,
+					"method", method,
+					"user", userID,
+					"err", insErr,
+				)
 			}
 			return nil
 		}

--- a/middleware/bearer_jwt.go
+++ b/middleware/bearer_jwt.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -33,12 +34,14 @@ func BearerJWT(a *auth.Authenticator, audience string) echo.MiddlewareFunc {
 			token := strings.TrimSpace(raw[len("Bearer "):])
 			idt, err := verifier.Verify(c.Request().Context(), token)
 			if err != nil {
+				slog.Debug("jwt verification failed", "path", c.Request().URL.Path, "err", err)
 				return apijson.Error(c, http.StatusUnauthorized, "UNAUTHORIZED", "Invalid token")
 			}
 			var claims struct {
 				Sub string `json:"sub"`
 			}
 			if err := idt.Claims(&claims); err != nil || claims.Sub == "" {
+				slog.Debug("jwt claims invalid", "path", c.Request().URL.Path, "err", err)
 				return apijson.Error(c, http.StatusUnauthorized, "UNAUTHORIZED", "Invalid claims")
 			}
 			c.Set(CtxAPIUserID, claims.Sub)

--- a/router/httperror.go
+++ b/router/httperror.go
@@ -1,0 +1,119 @@
+package router
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sknutsen/planner/internal/apijson"
+)
+
+func isAPIRequest(c echo.Context) bool {
+	return strings.HasPrefix(c.Request().URL.Path, "/api/v1")
+}
+
+// setupHTTPErrorHandler logs unhandled errors and returns consistent JSON for /api/v1.
+func setupHTTPErrorHandler(e *echo.Echo) {
+	defaultHandler := e.HTTPErrorHandler
+	e.HTTPErrorHandler = func(err error, c echo.Context) {
+		if c.Response().Committed {
+			return
+		}
+
+		if isAPIRequest(c) {
+			var he *echo.HTTPError
+			if errors.As(err, &he) {
+				code := httpStatusToAPICode(he.Code)
+				msg := httpErrorMessage(he)
+				if he.Code >= http.StatusInternalServerError {
+					apijson.ServerError(c, msg, err)
+					return
+				}
+				_ = apijson.Error(c, he.Code, code, msg)
+				return
+			}
+			apijson.ServerError(c, "An unexpected error occurred.", err)
+			return
+		}
+
+		defaultHandler(err, c)
+	}
+}
+
+func setupRecover(e *echo.Echo) {
+	e.Use(middlewareRecover())
+}
+
+func middlewareRecover() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = recoverToError(r)
+					attrs := []any{
+						"method", c.Request().Method,
+						"path", c.Request().URL.Path,
+						"panic", r,
+					}
+					if rid := c.Response().Header().Get(echo.HeaderXRequestID); rid != "" {
+						attrs = append(attrs, "request_id", rid)
+					}
+					slog.Error("panic recovered", attrs...)
+
+					if isAPIRequest(c) && !c.Response().Committed {
+						_ = apijson.ServerError(c, "An unexpected error occurred.", err)
+						err = nil
+					}
+				}
+			}()
+			return next(c)
+		}
+	}
+}
+
+func recoverToError(r any) error {
+	switch v := r.(type) {
+	case error:
+		return v
+	case string:
+		return errors.New(v)
+	default:
+		return errors.New("panic")
+	}
+}
+
+func httpStatusToAPICode(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "BAD_REQUEST"
+	case http.StatusUnauthorized:
+		return "UNAUTHORIZED"
+	case http.StatusNotFound:
+		return "NOT_FOUND"
+	case http.StatusConflict:
+		return "CONFLICT"
+	case http.StatusServiceUnavailable:
+		return "MISCONFIGURED"
+	default:
+		if status >= http.StatusInternalServerError {
+			return "SERVER_ERROR"
+		}
+		return "BAD_REQUEST"
+	}
+}
+
+func httpErrorMessage(he *echo.HTTPError) string {
+	switch msg := he.Message.(type) {
+	case string:
+		if msg != "" {
+			return msg
+		}
+	case error:
+		if msg != nil {
+			return msg.Error()
+		}
+	}
+	return http.StatusText(he.Code)
+}

--- a/router/router.go
+++ b/router/router.go
@@ -1,9 +1,8 @@
 package router
 
 import (
-	"fmt"
+	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo-contrib/session"
@@ -15,12 +14,40 @@ import (
 )
 
 func Setup(e *echo.Echo, h *handler.Handler) {
+	setupHTTPErrorHandler(e)
+
+	e.Use(middleware.RequestID())
+	e.Use(middlewareRecover())
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
-		LogStatus: true,
-		LogURI:    true,
-		LogMethod: true,
+		LogStatus:   true,
+		LogURI:      true,
+		LogMethod:   true,
+		LogLatency:  true,
+		LogError:    true,
+		LogRemoteIP: true,
 		LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
-			fmt.Printf("%v %v %v status: %v error: %v\n", v.StartTime.Format(time.RFC822), v.Method, v.URI, v.Status, v.Error)
+			attrs := []any{
+				"method", v.Method,
+				"path", v.URI,
+				"status", v.Status,
+				"latency", v.Latency.String(),
+				"remote_ip", v.RemoteIP,
+			}
+			if rid := c.Response().Header().Get(echo.HeaderXRequestID); rid != "" {
+				attrs = append(attrs, "request_id", rid)
+			}
+			if v.Error != nil {
+				attrs = append(attrs, "err", v.Error)
+			}
+
+			switch {
+			case v.Status >= http.StatusInternalServerError:
+				slog.Error("request", attrs...)
+			case v.Status >= http.StatusBadRequest:
+				slog.Warn("request", attrs...)
+			default:
+				slog.Info("request", attrs...)
+			}
 			return nil
 		},
 	}))


### PR DESCRIPTION
- Add apijson.ServerError to log server errors and optionally include error.detail when API_DEBUG is set
- Handle /api/v1 errors and panics with consistent JSON responses
- Replace fmt request logging with slog and request IDs (LOG_LEVEL)